### PR TITLE
Added permissions to run on all cragslist domains

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,23 +1,49 @@
 {
     "name": "Craigslist Preview",
-    "version": "1.0.21",
+    "version": "1.0.22",
     "manifest_version" : 2,
     "description": "Extension to prefetch Craigslist ad images",
     "icons": { "48": "icon48.png",
                "128": "icon128.png" },
     "permissions": [
-        "http://*.craigslist.org/",
-        "http://*.craigslist.ca/",
-        "http://*.craigslist.hk/",
-        "http://*.craigslist.co.uk/"
+        "*://*.craigslist.org/*",
+        "*://*.craigslist.ca/*",
+        "*://*.craigslist.at/*",
+        "*://*.craigslist.cz/*",
+        "*://*.craigslist.fi/*",
+        "*://*.craigslist.de/*",
+        "*://*.craigslist.gr/*",
+        "*://*.craigslist.it/*",
+        "*://*.craigslist.pl/*",
+        "*://*.craigslist.pt/*",
+        "*://*.craigslist.es/*",
+        "*://*.craigslist.se/*",
+        "*://*.craigslist.ch/*",
+        "*://*.craigslist.com/*",
+        "*://*.craigslist.co/*",
+        "*://*.craigslist.hk/*",
+        "*://*.craigslist.jp/*"
     ],
     "content_scripts": [
         {
             "matches": [
-                "http://*.craigslist.org/*",
-                "http://*.craigslist.ca/*",
-                "http://*.craigslist.hk/*",
-                "http://*.craigslist.co.uk/*"
+                "*://*.craigslist.org/*",
+                "*://*.craigslist.ca/*",
+                "*://*.craigslist.at/*",
+                "*://*.craigslist.cz/*",
+                "*://*.craigslist.fi/*",
+                "*://*.craigslist.de/*",
+                "*://*.craigslist.gr/*",
+                "*://*.craigslist.it/*",
+                "*://*.craigslist.pl/*",
+                "*://*.craigslist.pt/*",
+                "*://*.craigslist.es/*",
+                "*://*.craigslist.se/*",
+                "*://*.craigslist.ch/*",
+                "*://*.craigslist.com/*",
+                "*://*.craigslist.co/*",
+                "*://*.craigslist.hk/*",
+                "*://*.craigslist.jp/*"
             ],
             "js": [
                 "jquery-1.3.2.min.js",


### PR DESCRIPTION
Wasn't running on a lot of TLDs used by graigslist, so I did a regex match on http://www.craigslist.org/about/sites to get all the TLDs, and added them to manifest.

Also I've replaced `http` with `*` so it would also run on `https`.
