### PR TITLE
Create a space for images before load so that when going back to list, scroll isn't messed up

### DIFF
--- a/src/cl.css
+++ b/src/cl.css
@@ -3,6 +3,11 @@
     background-color: #f0f0f0
 }
 
+.clPrevImg
+{
+    min-height:200px;
+}
+
 .clPrevImg img
 {
     padding: 1px 3px 1px 3px;

--- a/src/cl.js
+++ b/src/cl.js
@@ -5,11 +5,13 @@ $(function()
     $('p.row').each(
         function()
         {
-            var a = $(this).find("a");
-            var entryDiv = $(this).wrap('<div class="entryDiv"></div>').parent().get(0);
-            var clPrevImg = $(entryDiv).append('<div class="clPrevImg"></div>').find(".clPrevImg");
-            hrefs.push({ href: $(a).attr("href"), div: $(clPrevImg) });
-        }
+	    if($(this).find(".px .p").text()==' pic'){
+		var a = $(this).find("a");
+		var entryDiv = $(this).wrap('<div class="entryDiv"></div>').parent().get(0);
+		var clPrevImg = $(entryDiv).append('<div class="clPrevImg"></div>').find(".clPrevImg");
+		hrefs.push({ href: $(a).attr("href"), div: $(clPrevImg) });
+            }
+	}
     );
 
     getImages(hrefs, {});

--- a/src/cl.js
+++ b/src/cl.js
@@ -5,7 +5,8 @@ $(function()
     $('p.row').each(
         function()
         {
-	    if($(this).find(".px .p").text()==' pic'){
+	    var picText = $(this).find(".px .p").text();
+	    if(picText.indexOf(' pic') !== -1){
 		var a = $(this).find("a");
 		var entryDiv = $(this).wrap('<div class="entryDiv"></div>').parent().get(0);
 		var clPrevImg = $(entryDiv).append('<div class="clPrevImg"></div>').find(".clPrevImg");


### PR DESCRIPTION
An issue I had with the extension is that if you clicked on an ad, and then clicked back, the loading of the images would totally throw off your scrollbar position. This change makes it so even before images are loaded, their is 200px of height space given to them, so the scroll doesn't get messed up. 
